### PR TITLE
chore: accept new Cruft update

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/kjaymiller/cookiecutter-relecloud",
-  "commit": "c79db2e58d74889c73353442c2d65ded61545065",
+  "commit": "d507bca0f2f67be7274add230496456327acef14",
   "checkout": null,
   "context": {
     "cookiecutter": {

--- a/README.md
+++ b/README.md
@@ -6,7 +6,17 @@ This project deploys a web application for a space travel agency using Flask. Th
 
 This project has [Dev Container support](https://code.visualstudio.com/docs/devcontainers/containers), so it will be setup automatically if you open it in Github Codespaces or in local VS Code with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
 
-If you're not using one of those options for opening the project, then you'll need to:
+If you're *not* using one of those options for opening the project, then you'll need to:
+
+1. Start up a local PostgreSQL server, create a database for the app, and set the following environment variables according to your database configuration.
+
+```shell
+export POSTGRES_HOST=localhost
+export POSTGRES_PORT=5432
+export POSTGRES_DATABASE=<YOUR DATABASE>
+export POSTGRES_USERNAME=<YOUR USERNAME>
+export POSTGRES_PASSWORD=<YOUR PASSWORD>
+```
 
 1. Create a [Python virtual environment](https://docs.python.org/3/tutorial/venv.html#creating-virtual-environments) and activate it.
 
@@ -46,7 +56,7 @@ python3 -m flask --app src.flaskapp run --reload --port=8000
 
     ```sh
     python3 -m pip install -r requirements-dev.in
-    playwright install --with-deps
+    python3 -m playwright install --with-deps
     ```
 
 3. Run the tests:

--- a/src/flaskapp/config/development.py
+++ b/src/flaskapp/config/development.py
@@ -10,6 +10,7 @@ dbuser = os.environ["POSTGRES_USERNAME"]
 dbpass = os.environ["POSTGRES_PASSWORD"]
 dbhost = os.environ["POSTGRES_HOST"]
 dbname = os.environ["POSTGRES_DATABASE"]
-DATABASE_URI = f"postgresql+psycopg2://{dbuser}:{dbpass}@{dbhost}/{dbname}"
+dbport = os.environ.get("POSTGRES_POST", 5432)
+DATABASE_URI = f"postgresql+psycopg2://{dbuser}:{dbpass}@{dbhost}:{dbport}/{dbname}"
 
 TIME_ZONE = "UTC"

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -12,9 +12,8 @@ def app():
     """Session-wide test `Flask` application."""
     config_override = {
         "TESTING": True,
-        "SQLALCHEMY_DATABASE_URI": os.environ.get(
-            "TEST_DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/postgres"
-        ),
+        # Allows for override of database to separate test from dev environments
+        "SQLALCHEMY_DATABASE_URI": os.environ.get("TEST_DATABASE_URL", os.environ.get("DATABASE_URI")),
     }
     app = create_app(config_override)
 


### PR DESCRIPTION
This pull request includes changes related to setting up a local PostgreSQL server and environment variables for database configuration, modifying the `DATABASE_URI` to include `POSTGRES_PORT` environment variable, updating the commit hash in the `.cruft.json` file, and allowing for overriding the database for testing purposes.

Main interface changes:

* <a href="diffhunk://#diff-8c6e734513b4797516d5da0b75901b872a83b2dab327778a6fe308de3d14d5cbL13-R14">`src/flaskapp/config/development.py`</a>: Modified `DATABASE_URI` to include `POSTGRES_PORT` environment variable, allowing for port specification in environment variables.

Configuration improvements:

* <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-R19">`README.md`</a>: Added instructions for setting up a local PostgreSQL server and environment variables for database configuration, and modified a command for clarity. <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-R19">[1]</a> <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L49-R59">[2]</a>

Testing improvements:

* <a href="diffhunk://#diff-d693b2faa093742e7045e9d6606e499d5ff59a8c9625968286d5abf230c28e35L15-R16">`src/tests/conftest.py`</a>: Updated `SQLALCHEMY_DATABASE_URI` to allow for overriding the database for testing purposes.

Other changes:

* <a href="diffhunk://#diff-7b1438cc5a871699533a558b896508c905226be2ee0f8aab1ebd6d2795e79f5eL3-R3">`.cruft.json`</a>: Updated commit hash in `.cruft.json` file.