### PR TITLE
Web App Manifest

### DIFF
--- a/src/static/manifest.json
+++ b/src/static/manifest.json
@@ -1,0 +1,30 @@
+{
+    "name": "ReleCloud Space Tourism",
+    "short_name": "ReleCloud",
+    "start_url": ".",
+    "display": "standalone",
+    "background_color": "#fff",
+    "description": "ReleCloud Space Tourism",
+    "icons": [
+        {
+            "src": "/static/res/img/favicon.ico",
+            "sizes": "32x32",
+            "type": "image/x-icon"
+        },
+        {
+            "src": "/static/res/img/favicon-120-precomposed.png",
+            "sizes": "120x120",
+            "type": "image/png"
+        },
+        {
+            "src": "/static/res/img/favicon-152-precomposed.png",
+            "sizes": "152x152",
+            "type": "image/png"
+        },
+        {
+            "src": "/static/res/img/favicon-192.png",
+            "sizes": "192x192",
+            "type": "image/png"
+        }
+    ]
+}

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -18,7 +18,7 @@
      <link rel="apple-touch-icon" sizes="120x120" href="{{ url_for('static', filename='res/img/favicon-120-precomposed.png') }}">
      
      <!-- Chrome for Android -->
-     <link rel="manifest" href="manifest.json">
+     <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
      <link rel="icon" sizes="192x192" href="{{ url_for('static', filename='res/img/favicon-192.png') }}">
 
     <title>


### PR DESCRIPTION
- Add the `manifest.json` file 
- Use `url_for` manifest.json

Error:

![Error-web_app-manifest-2024-01-13 115022](https://github.com/Azure-Samples/azure-flask-postgres-flexible-aca/assets/44526468/c9171403-3dc4-4143-bd69-797ac7343e66)

Fixed:

![Fix-web_app-manifest-2024-01-13 115022](https://github.com/Azure-Samples/azure-flask-postgres-flexible-aca/assets/44526468/46e8ff26-29d3-4020-be20-db3ba1bf3255)

Result:

![ReleCloud_Space_Tourism-webapp-2024-01-13 143928](https://github.com/Azure-Samples/azure-flask-postgres-flexible-aca/assets/44526468/954db4b8-cae0-43c2-8cae-b9df1c6e5c05)
